### PR TITLE
adding name as a component of a complete profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This makes it easier for your team to know who you are, but most of all, it help
 
 A complete [public profile](https://github.com/settings/profile) includes:
 
+- **Name:** Your first or first and last name.  
 - **Company:** Your government agency.
 - **Location:** Your primary work location (City, State).
 - **Email:** A [verified government email address](https://help.github.com/articles/verifying-your-email-address/).


### PR DESCRIPTION
A small bit that is very helpful is for the user to populate the name field in their [profile settings](https://github.com/settings/profile).  This makes the profile more complete and makes it easier to complete b/c it facilitates auto-complete.
