### PR TITLE
Allow non-government emails on public profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A complete [public profile](https://github.com/settings/profile) includes:
 
 - **Company:** Your government agency.
 - **Location:** Your primary work location (City, State).
-- **Email:** A [verified government email address](https://help.github.com/articles/verifying-your-email-address/).
+- **Email:** A [valid email address](https://help.github.com/articles/verifying-your-email-address/).
 
 #### [Add a profile avatar](https://help.github.com/articles/how-do-i-set-up-my-profile-picture/)
 


### PR DESCRIPTION
Since I'm pretty sure we're going for the ability for staff to use their GitHub accounts in a fully dual role, as work and personal accounts, requiring the email on one's public profile to be their government email address is in tension with that.

We definitely should have staff associate their work email with their account, and associate it with work commits. I think we can safely remain neutral on which email address they use for their public profile.
